### PR TITLE
Update DeployAVDSessionHostReplacer.json

### DIFF
--- a/deploy/arm/DeployAVDSessionHostReplacer.json
+++ b/deploy/arm/DeployAVDSessionHostReplacer.json
@@ -109,7 +109,8 @@
       ]
     },
     "IntuneEnrollment": {
-      "type": "bool"
+      "type": "bool",
+      "defaultValue": false
     },
     "ADDomainName": {
       "type": "string",


### PR DESCRIPTION
default value (false) for IntuneEnrollment parameter to avoid validation error when trying to deploy using Microsoft Entra Domain Services as identity service provider (already tested in my environment)