### PR TITLE
Domain Join issues fixed

### DIFF
--- a/deploy/arm/DeployAVDSessionHostReplacer.json
+++ b/deploy/arm/DeployAVDSessionHostReplacer.json
@@ -1066,7 +1066,7 @@
                             "settings": {
                               "Name": "[[parameters('DomainJoinObject').DomainName]",
                               "OUPath": "[[parameters('DomainJoinObject').OUPath]",
-                              "User": "[[format('{0}\\{1}', parameters('DomainJoinObject').DomainName, parameters('DomainJoinObject').UserName)]",
+                              "User": "[[format('{0}\\{1}', parameters('DomainJoinObject').DomainName, parameters('DomainJoinObject').DomainJoinUserName)]",
                               "Restart": "true",
                               "Options": 3
                             },

--- a/deploy/arm/DeployAVDSessionHostReplacer.json
+++ b/deploy/arm/DeployAVDSessionHostReplacer.json
@@ -1065,7 +1065,7 @@
                             "autoUpgradeMinorVersion": true,
                             "settings": {
                               "Name": "[[parameters('DomainJoinObject').DomainName]",
-                              "OUPath": "[[parameters('DomainJoinObject').OUPath]",
+                              "OUPath": "[[parameters('DomainJoinObject').ADOUPath]",
                               "User": "[[format('{0}\\{1}', parameters('DomainJoinObject').DomainName, parameters('DomainJoinObject').DomainJoinUserName)]",
                               "Restart": "true",
                               "Options": 3

--- a/docs/CodeDeploy.md
+++ b/docs/CodeDeploy.md
@@ -66,7 +66,7 @@ $TemplateParameters = @{
 $paramNewAzResourceGroupDeployment = @{
     Name = 'AVDSessionHostReplacer'
     ResourceGroupName = $ResourceGroupName
-    TemplateFile = 'https://raw.githubusercontent.com/Azure/AVDSessionHostReplacer/main/deploy/arm/DeployAVDSessionHostReplacer.json'
+    TemplateUri = 'https://raw.githubusercontent.com/Azure/AVDSessionHostReplacer/main/deploy/arm/DeployAVDSessionHostReplacer.json'
     # If you cloned the repo and want to deploy using the bicep file use this instead of the above line
     #TemplateFile = '.\deploy\bicep\DeployAVDSessionHostReplacer.bicep'
     TemplateParameterObject = $TemplateParameters


### PR DESCRIPTION
Got two errors while deploying to Active Directory joined host pool

The first error was : 
Unable to process template language expressions for resource '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/XXX/providers/Microsoft.Compute/virtualMachines/XXX-02/extensions/DomainJoin' at line '1' and column '7550'. 'The language expression property 'OUPath' doesn't exist, available properties are 'DomainType, ADOUPath, DomainName, DomainJoinUserName'.' (Code: InvalidTemplate)

After changing the "OUPath": "[[parameters('DomainJoinObject').OUPath]" to "OUPath": "[[parameters('DomainJoinObject').ADOUPath]"

Got the following error 

Unable to process template language expressions for resource '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/XXX/providers/Microsoft.Compute/virtualMachines/XXX-02/extensions/DomainJoin' at line '1' and column '7550'. 'The language expression property 'UserName' doesn't exist, available properties are 'DomainType, ADOUPath, DomainName, DomainJoinUserName'.' (Code: InvalidTemplate)

changed "User": "[[format('{0}\\{1}', parameters('DomainJoinObject').DomainName, parameters('DomainJoinObject').UserName)]",  to "User": "[[format('{0}\\{1}', parameters('DomainJoinObject').DomainName, parameters('DomainJoinObject').DomainJoinUserName)]"

Also changed the CodeDeploy.md where TemplateUri should be used instead of TeamplateFile